### PR TITLE
Add webpage for Math Problem Solving sessions to share Problem and Solution PDFs

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -78,7 +78,7 @@
     </head>
   </head>
 
-  <body>
+  <body class="animate-bg">
     <div id="loader"></div>
     
     <header>

--- a/css/common.css
+++ b/css/common.css
@@ -21,15 +21,26 @@ body {
   );
   color: #eeeeee;
 }
+
 #loader{
   position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: #fff;
   z-index: 99999;
+
+  background: linear-gradient(230deg, #180834, #26032c, #101010);
+  background-size: 600% 600%;
+  animation: loader-bg 3s ease infinite;
 }
+
+@keyframes loader-bg {
+  0%{background-position:50% 0%}
+  50%{background-position:50% 100%}
+  100%{background-position:50% 0%}
+}
+
 header {
   position: fixed;
   top: 0;

--- a/events/index.html
+++ b/events/index.html
@@ -76,7 +76,7 @@
   <script src="../js/footerinclude.js"></script>
 </head>
 
-<body>
+<body class="animate-bg">
   <div id="loader"></div>
   
   <header>

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     <script src="js/footerinclude.js" type="text/javascript"></script>
   </head>
 
-  <body>
+  <body class="animate-bg">
     <div id="loader"></div>
     
     <header>

--- a/js/common.js
+++ b/js/common.js
@@ -46,20 +46,19 @@ function openMenu() {
   document.querySelector("#nav-hamburger p").style.display = "block";
 }
 
-function setBgColor() {
-  var percent =
-    document.documentElement.scrollTop /
-    (document.documentElement.scrollHeight -
-      document.documentElement.clientHeight);
-  document.querySelector("body").style.background = `linear-gradient(
+function setBgColor(bodyElement) {
+  var percent = document.documentElement.scrollTop / (document.documentElement.scrollHeight - document.documentElement.clientHeight);
+  bodyElement.style.background = `linear-gradient(
       #180834 0,
       #26032c calc(100vh + 0px),
-      rgb(${16 + percent * (15 - 16)}, ${16 + percent * (84 - 16)}, ${
-    16 + percent * (138 - 16)
-  }) 100vh
+      rgb(${16 + percent * (15 - 16)}, ${16 + percent * (84 - 16)}, ${16 + percent * (138 - 16)}) 100vh
     )`;
 }
 
-window.addEventListener("scroll", function () {
-  setBgColor();
-});
+const bodyElement = document.querySelector("body.animate-bg");
+
+if (bodyElement) {
+  window.addEventListener("scroll", function () {
+    setBgColor(bodyElement);
+  });
+}

--- a/learn/index.html
+++ b/learn/index.html
@@ -76,7 +76,7 @@
     <script src="../js/footerinclude.js"></script>
   </head>
 
-  <body>
+  <body class="animate-bg">
     <div id="loader"></div>
     
     <header>

--- a/pages/ideathon/ideathon.css
+++ b/pages/ideathon/ideathon.css
@@ -9,7 +9,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-	align-items: center;
+	  align-items: center;
 }
 
 #title img {

--- a/pages/ideathon/index.html
+++ b/pages/ideathon/index.html
@@ -80,7 +80,7 @@
     <script src="/js/footerinclude.js" type="text/javascript"></script>
   </head>
 
-  <body>
+  <body class="animate-bg">
     <header>
       <header-component></header-component>
     </header>

--- a/pages/launch/index.html
+++ b/pages/launch/index.html
@@ -32,7 +32,7 @@
   <script src="../../js/footerinclude.js"></script>
 </head>
 
-<body>
+<body class="animate-bg">
   <div id="loader"></div>
   <header>
     <header-component></header-component>

--- a/pages/math-sessions/index.html
+++ b/pages/math-sessions/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="manifest" href="manifest.json" />
+
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="application-name" content="Databased" />
+    <meta name="apple-mobile-web-app-title" content="Databased" />
+    <meta name="theme-color" content="#101010" />
+    <meta name="msapplication-navbutton-color" content="#101010" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
+    <meta name="msapplication-starturl" content="/" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="192x192"
+      href="/img/icon-192x192.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      type="image/png"
+      sizes="192x192"
+      href="/img/icon-192x192.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="256x256"
+      href="/img/icon-256x256.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      type="image/png"
+      sizes="256x256"
+      href="/img/icon-256x256.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="384x384"
+      href="/img/icon-384x384.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      type="image/png"
+      sizes="384x384"
+      href="/img/icon-384x384.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="512x512"
+      href="/img/icon-512x512.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      type="image/png"
+      sizes="512x512"
+      href="/img/icon-512x512.png"
+    />
+
+    <title>Mathematics | Databased</title>
+    <link rel="stylesheet" href="../../css/common.css" />
+    <link rel="stylesheet" href="./math.css" />
+    
+    <!-- Google Material Icons -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+    
+    <link rel="icon" href="/img/favicon-32x32.png" type="image/x-icon" />
+    <script src="/js/footerinclude.js" type="text/javascript"></script>
+  </head>
+
+  <body>
+    <header>
+      <header-component></header-component>
+    </header>
+
+    <div id="title">
+      <h1>Math</h1>
+      <h2>Problem Solving Sessions</h2>
+    </div>
+
+    <main>
+      <h2>Upcoming and Previous Sessions</h2>
+
+      <!-- Populated by math.js -->
+      <div id="session-list"></div>
+    </main>
+    
+    <footer>
+      <footer-component></footer-component>
+    </footer>
+
+    <script src="../../js/common.js"></script>
+    <script src="./math.js"></script>
+  </body>
+</html>

--- a/pages/math-sessions/index.html
+++ b/pages/math-sessions/index.html
@@ -81,17 +81,15 @@
   </head>
 
   <body>
+    <div id="loader"></div>
+
     <header>
       <header-component></header-component>
     </header>
 
-    <div id="title">
-      <h1>Math</h1>
-      <h2>Problem Solving Sessions</h2>
-    </div>
-
     <main>
-      <h2>Upcoming and Previous Sessions</h2>
+      <h1>Mathematics Problem Solving</h1>
+      <h2><span style="color: rgb(76, 231, 99);">Upcoming</span> and Previous Sessions</h2>
 
       <!-- Populated by math.js -->
       <div id="session-list"></div>

--- a/pages/math-sessions/math.css
+++ b/pages/math-sessions/math.css
@@ -1,0 +1,132 @@
+#title {
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.7) 0%,  rgba(0, 0, 0, 0.7) 100%), url(../../img/backgroundsbundle/Kander.png);
+  text-align: center;
+  height: 100vh;
+  padding-top: 100px;
+  padding-bottom: 80px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
+}
+
+#title h1 {
+  font-size: 120px;
+  text-shadow: #000 0px 0px 5px;
+}
+
+#title h2 {
+  font-size: 60px;
+  text-shadow: #000 0px 0px 5px;
+}
+
+main{
+  min-height: 100vh;
+  text-align: center;
+  padding: 20px 0;
+}
+
+main > h2 {
+  font-size: 40px;
+  margin: 20px 0;
+}
+
+#session-list {
+  margin-top: 40px;
+}
+
+.session {
+  height: 70px;
+  padding: 15px;
+  margin: 20px 0;
+  border-radius: 5px;
+
+  background-color: rgba(0, 0, 0, 0.5);
+  box-shadow: inset rgba(255, 255, 255) 0 0 5px;
+}
+
+.session.upcoming {
+  box-shadow: inset rgba(0, 200, 0) 0 0 5px;
+}
+
+.session-label {
+  font-size: 32px;
+  line-height: 40px;
+  float: left;
+}
+
+.session-button {
+  border: 2px #ffffff solid;
+  padding: 5px 10px 5px 10px;
+  height: 40px;
+  width: auto;
+  margin-left: 10px;
+  float: right;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+  cursor: pointer;
+  text-decoration: none;
+
+  transition: background-color 0.1s;
+}
+
+.session-button.disabled {
+  border: 2px #999 solid;
+  cursor: not-allowed;
+}
+
+.session-button.disabled:hover {
+  background-color: transparent;
+}
+
+.session-button.disabled span {
+  color: #999;
+}
+
+.session-button .material-symbols-outline {
+  line-height: 40px;
+}
+
+.session-button-icon {
+  height: 25px;
+}
+
+.session-button-label {
+  width: auto;
+  text-align: center;
+  font-family: Montserrat;
+  font-size: 20px;
+  line-height: 40px;
+  text-transform: uppercase;
+
+  margin-left: 10px;
+}
+
+.session-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+@media only screen and (max-width: 700px) {
+  .session {
+    height: auto;
+    padding: 10px 20px;
+  }
+
+  .session-label {
+    float: none;
+  }
+
+  .session-button {
+    float: none;
+    margin: 10px 0;
+    justify-content: center;
+  }
+}

--- a/pages/math-sessions/math.css
+++ b/pages/math-sessions/math.css
@@ -1,4 +1,8 @@
-#title {
+body {
+  background-attachment: fixed;
+}
+
+/* #title {
   background: linear-gradient(90deg, rgba(0, 0, 0, 0.7) 0%,  rgba(0, 0, 0, 0.7) 100%), url(../../img/backgroundsbundle/Kander.png);
   text-align: center;
   height: 100vh;
@@ -23,12 +27,12 @@
 #title h2 {
   font-size: 60px;
   text-shadow: #000 0px 0px 5px;
-}
+} */
 
 main{
   min-height: 100vh;
   text-align: center;
-  padding: 20px 0;
+  padding: 100px 0 20px 0;
 }
 
 main > h2 {

--- a/pages/math-sessions/math.js
+++ b/pages/math-sessions/math.js
@@ -1,0 +1,46 @@
+(async () => {
+
+  let airtable_res = await fetch(
+    `https://api.airtable.com/v0/appHwUzo4ARCQQlwr/Math%20Sessions?maxRecords=20&view=Grid%20view`,
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer pat2bEq3dsaXHSBH9.2edd33a7b1c2de8fd5e4fe14b82900cf807d2c9b56dfead6a8bdd48715826409`,
+      },
+    }
+  );
+  
+  let mps_data = await airtable_res.json();  
+  let session_list = document.getElementById("session-list");
+
+  for (session of mps_data.records) {
+    session_info = {
+      date: new Date(session.fields.Date),
+      problems: session.fields["Problems PDF"]?.[0].url || "",
+      solutions: session.fields["Solutions PDF"]?.[0].url || "",
+    };
+
+    let session_div = document.createElement("div");
+    session_div.classList.add("session");
+    
+    if (session_info.date > Date.now())
+      session_div.classList.add("upcoming");
+
+    session_div.innerHTML = `
+      <span class="session-label">${session_info.date.toLocaleDateString("en-IN", { day: "numeric", month: "short", year: "numeric" })}</span>
+      <a class="session-button${session_info.solutions ? "" : " disabled"}" href="${session_info.solutions || "javascript:void(0)"}">
+        <span class="material-symbols-outlined">inventory</span>
+        <span class="session-button-label"> Solutions </span>
+      </a>
+      <a class="session-button${session_info.problems ? "" : " disabled"}" href="${session_info.problems || "javascript:void(0)"}">
+        <span class="material-symbols-outlined">assignment</span>
+        <span class="session-button-label"> Problems </span>
+      </a>
+    `;
+
+    session_list.appendChild(session_div);
+  }
+
+})()

--- a/pages/math-sessions/math.js
+++ b/pages/math-sessions/math.js
@@ -15,7 +15,7 @@
   let mps_data = await airtable_res.json();  
   let session_list = document.getElementById("session-list");
 
-  for (session of mps_data.records) {
+  for (let session of mps_data.records) {
     session_info = {
       date: new Date(session.fields.Date),
       problems: session.fields["Problems PDF"]?.[0].url || "",
@@ -43,4 +43,6 @@
     session_list.appendChild(session_div);
   }
 
-})()
+  // Remove loader
+  unload();
+})();

--- a/pages/open-day/index.html
+++ b/pages/open-day/index.html
@@ -80,7 +80,7 @@
     <script src="/js/footerinclude.js" type="text/javascript"></script>
   </head>
 
-  <body>
+  <body class="animate-bg">
     <header>
       <header-component></header-component>
     </header>

--- a/pages/paradox/index.html
+++ b/pages/paradox/index.html
@@ -77,7 +77,7 @@
     <script src="../../js/footerinclude.js"></script>
   </head>
 
-  <body>
+  <body class="animate-bg">
     <div id="loader"></div>
     
     <header>

--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -80,7 +80,7 @@
     <script src="/js/footerinclude.js" type="text/javascript"></script>
   </head>
 
-  <body>
+  <body class="animate-bg">
     <header>
       <header-component></header-component>
     </header>


### PR DESCRIPTION
**Added a page for regularly hosted Math Problem Solving sessions**:
- Location: `/pages/math-sessions/`
- Data of sessions maintained and retrieved with Airtable
- Allows downloading of Problems PDF and Solutions PDF if uploaded
- Upcoming sessions are highlighted with a green border (actually inset shadow)

This page does not feature the default animated background color and full-height title section. I felt it better to keep it simple being a resource page.

**Other changes**:
- Made the animated background color effect non-default. It can be enabled by adding the `.animate-bg` class to the body tag. Also, slightly optimized its implementation.
- Added a simple gradient animation to the loader to replace the plain white loader in use.

_Screenshot of Math Sessions page_
![image](https://github.com/user-attachments/assets/4ffa62c2-2963-46e9-a71d-4967006e6c16)

## TODO
Currently there is no link on any page to facilitate reaching the math sessions page. I am thinking of adding a small section on the home page featuring regular events where the latest math session would be featured (along with CP or other sessions). But there are many changes I want to make to the Home page since some of the current layout is scuffed (Contact Section). This can be done in a later PR. Suggestions regarding this are requested.